### PR TITLE
Fixed NoneType bug

### DIFF
--- a/pyrchidekt/deck.py
+++ b/pyrchidekt/deck.py
@@ -155,7 +155,7 @@ class Deck:
 
         for card in retval.cards:
             added_to_categories = False
-            if len(card.categories):
+            if card.categories and len(card.categories):
                 for category in card.categories:
                     deck_category = categories.get(category)
                     if(deck_category is None):


### PR DESCRIPTION
When running on the example program, we get
```python
Traceback (most recent call last):
  File "[redacted :3]/pyrchidekt/main.py", line 3, in <module>
    deck = getDeckById(1)
           ^^^^^^^^^^^^^^
  File "[redacted :3]/pyrchidekt/pyrchidekt/api.py", line 27, in getDeckById
    return Deck.fromJson(response.json())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "[redacted :3]/pyrchidekt/pyrchidekt/deck.py", line 158, in fromJson
    if len(card.categories):
       ^^^^^^^^^^^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()
```
Looking at `class Data.fromJson`, `data["categories"]` can seem to only return the `Commander` catergory, and also cards in the data, seem to return `null` as the data type, however when running they seems to work fine and this fix seems to work 
