### PR TITLE
Add "Canadian Highlander" to `LegalFormat`

### DIFF
--- a/pyrchidekt/cards.py
+++ b/pyrchidekt/cards.py
@@ -124,7 +124,9 @@ class OracleCard:
                 "pauper": "not_legal",
                 "standard": "legal",
                 "future": "legal",
-                "predh": "not_legal"
+                "predh": "not_legal",
+                "future": "timeless",
+                "future": "canlander"
             },
             "manaCost": "{2}{W}{U}",
             "manaProduction": {

--- a/pyrchidekt/formats.py
+++ b/pyrchidekt/formats.py
@@ -25,6 +25,10 @@ class Format(Enum):
     OATHBREAKER = 14
 
 class LegalFormat(Enum):
+    """Enumerated wrapper around the legalities strings
+
+    This class is a wrapper around the card legalities format strings Archidekt uses
+    """
     ALCHEMY = 1
     LEGACY = 2
     OLD_SCHOOL = 3
@@ -48,6 +52,7 @@ class LegalFormat(Enum):
     FUTURE = 21
     PREDH = 22
     TIMELESS = 23
+    CANADIAN_HIGHLANDER = 24
 
     @staticmethod
     def fromString(input: str) -> LegalFormat:
@@ -98,5 +103,7 @@ class LegalFormat(Enum):
                 return LegalFormat.PREDH
             case "timeless":
                 return LegalFormat.TIMELESS
+            case "canlander":
+                return LegalFormat.CANADIAN_HIGHLANDER
             case _:
                 raise TypeError("Not a legal format")


### PR DESCRIPTION
As discussed in https://github.com/linkian209/pyrchidekt/issues/4.

I believe `Format` (as configured in the settings of a deck and gathered in `Deck`) is also outdated. In the settings of a deck on Archidekt, I see a lot more possible categories. Hence, this should be updated to be consistent with all available options.