### PR TITLE
Handle TypeError during card legality validation

### DIFF
--- a/pyrchidekt/cards.py
+++ b/pyrchidekt/cards.py
@@ -172,7 +172,7 @@ class OracleCard:
         for x in data["legalities"]:
             try:
                 legalities[LegalFormat(x.lower())] = data["legalities"][x]
-            except ValueError as e:
+            except (TypeError, ValueError) as e:
                 warn(
                     message=f"{e} -> skipping card legality\n"
                     f"For new formats, please file an issue at "


### PR DESCRIPTION
This was still throwing in my code a la:

```
   raise TypeError("Not a legal format")
TypeError: Not a legal format
```

The deck I tested with was this one:  
https://archidekt.com/decks/11211513

which was previously throwing a `TypeError` in the latest release and the latest GH release.